### PR TITLE
Add per-repo apply command (gas apply <id|ssh_alias>) (#2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `gas apply <id|ssh_alias>` applies a single account's identity to the
+  current repository (sets local user.name/user.email and rewrites the
+  origin remote to use the SSH alias)
 - MIT License
 - Contributing guidelines
 - GitHub Actions CI workflow (ShellCheck + bats tests)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ gas apply
 | `add` | Add a new account interactively |
 | `remove [id]` | Remove an account |
 | `list` | List all configured accounts |
-| `apply` | Apply configuration to system |
+| `apply [id]` | Apply configuration to system, or a single account (id or ssh_alias) to the current repository |
 | `validate` | Validate configuration and check for issues |
 | `audit [--fix]` | Audit repositories for identity mismatches (--fix to auto-fix) |
 | `current` | Show current active account for this directory (alias: `whoami`) |
@@ -154,6 +154,27 @@ $ gas current
     - ~/workspace/work
     - ~/projects/company
 ```
+
+### Applying an Account to the Current Repository
+
+Configure a single repository to use a specific account, regardless of where
+the repository lives on disk. Useful for one-off repos that sit outside any
+configured workspace, or when you want to override the workspace default.
+
+```bash
+$ cd ~/some/repo
+$ gas apply gh-work       # by SSH alias
+# or
+$ gas apply work          # by account ID
+```
+
+This sets the repository's local `user.name` and `user.email`, ensures
+the SSH host alias is present in `~/.ssh/config`, and rewrites the
+`origin` remote to use the alias (e.g. `git@github.com:user/repo.git` →
+`git@gh-work:user/repo.git`).
+
+Local Git config takes precedence over the global `includeIf` rules, so
+this works for repos inside *and* outside configured workspaces.
 
 ### Fixing Issues
 

--- a/lib/cli/help.sh
+++ b/lib/cli/help.sh
@@ -18,7 +18,8 @@ COMMANDS:
   add         Add a new account
   remove [id] Remove an account (interactive if no ID provided)
   list        List all configured accounts
-  apply       Apply configuration to system (SSH, Git, hooks)
+  apply [id]  Apply configuration to system (no id) or a single account
+              to the current repository (id or ssh_alias given)
   validate    Validate configuration and check for issues
   audit       Audit repositories for identity mismatches (--fix to auto-fix)
   current     Show current active account for this directory
@@ -38,8 +39,13 @@ EXAMPLES:
   # List all accounts
   git-auto-switch list
 
-  # Apply configuration after changes
+  # Apply configuration after changes (system-wide)
   git-auto-switch apply
+
+  # Apply a specific account to the current repository only
+  # (argument may be the account id or its ssh_alias)
+  cd ~/some/repo
+  git-auto-switch apply gh-work
 
   # Check for issues
   git-auto-switch validate

--- a/lib/commands/apply.sh
+++ b/lib/commands/apply.sh
@@ -12,6 +12,12 @@ cmd_apply() {
     die "Invalid state. Fix errors and try again."
   fi
 
+  # If an account ID is given, apply that account to the current repo only.
+  if [[ -n "${1:-}" ]]; then
+    apply_to_current_repo "$1"
+    return $?
+  fi
+
   local account_count
   account_count=$(get_account_count)
 
@@ -68,5 +74,90 @@ cmd_apply() {
     ssh_alias=$(echo "$account" | jq -r '.ssh_alias')
     echo "  ssh -T git@$ssh_alias"
   done
+  echo
+}
+
+# Apply a single account's identity to the current git repository.
+# The argument may be either the account ID or the account's SSH alias.
+# Sets local user.name/user.email and rewrites the origin remote to use
+# the SSH alias. If the alias is missing from ~/.ssh/config it is added,
+# so this works even when the user has never run a system-wide apply.
+apply_to_current_repo() {
+  local key="$1"
+
+  local account
+  account=$(get_account_by_id_or_alias "$key")
+  if [[ -z "$account" ]]; then
+    die "No account matches '$key' (by id or ssh_alias). Run 'git-auto-switch list' to see available accounts."
+  fi
+
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    die "Not in a git repository. Run this command from inside the repository you want to configure."
+  fi
+
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel)
+
+  local id ssh_alias ssh_key_path git_name git_email
+  id=$(echo "$account" | jq -r '.id')
+  ssh_alias=$(echo "$account" | jq -r '.ssh_alias')
+  ssh_key_path=$(echo "$account" | jq -r '.ssh_key_path')
+  git_name=$(echo "$account" | jq -r '.git_name')
+  git_email=$(echo "$account" | jq -r '.git_email')
+
+  echo
+  log_info "Applying account '$id' to repository: $repo_root"
+  echo
+
+  # Make sure the SSH host alias resolves. Only rewrite ~/.ssh/config when
+  # the alias is missing — avoids creating a backup on every invocation.
+  log_info "Step 1/3: Checking SSH config..."
+  if grep -q "^Host $ssh_alias\$" "$SSH_CONFIG" 2>/dev/null; then
+    log_info "SSH alias '$ssh_alias' already present in $SSH_CONFIG"
+  else
+    log_info "SSH alias '$ssh_alias' missing — refreshing $SSH_CONFIG"
+    apply_ssh_config
+  fi
+
+  # Warn (don't fail) if the SSH key file does not exist; the user can fix
+  # this later by running `git-auto-switch apply` (system-wide) which will
+  # generate the key.
+  local expanded_key
+  expanded_key=$(expand_path "$ssh_key_path")
+  if [[ ! -f "$expanded_key" ]]; then
+    log_warn "SSH key not found: $expanded_key"
+    log_warn "Run 'git-auto-switch apply' (no args) to generate the key."
+  fi
+
+  # Set local Git identity for this repository.
+  log_info "Step 2/3: Setting local Git identity..."
+  git -C "$repo_root" config user.name "$git_name"
+  git -C "$repo_root" config user.email "$git_email"
+  log_success "Set local Git identity: $git_name <$git_email>"
+
+  # Rewrite the origin remote to use the SSH host alias. If the remote
+  # currently points at a different alias (e.g. user is switching from
+  # 'personal' to 'work'), normalize it back to github.com first so the
+  # shared rewriter can process it. The character class excludes '.', so
+  # genuine github.com URLs never match this branch — they are passed
+  # through to rewrite_repo_remotes which handles them directly.
+  log_info "Step 3/3: Rewriting origin remote..."
+  local origin_url
+  origin_url=$(git -C "$repo_root" remote get-url origin 2>/dev/null || echo "")
+  if [[ -n "$origin_url" && "$origin_url" =~ ^git@([a-zA-Z0-9_-]+):(.*)$ ]]; then
+    local current_host="${BASH_REMATCH[1]}"
+    if [[ "$current_host" != "$ssh_alias" ]]; then
+      git -C "$repo_root" remote set-url origin "git@github.com:${BASH_REMATCH[2]}"
+    fi
+  fi
+  rewrite_repo_remotes "$repo_root" "$ssh_alias"
+
+  echo
+  log_success "Applied '$id' to $repo_root"
+  echo
+  echo "Verify with:"
+  echo "  git -C \"$repo_root\" config --local --get user.email"
+  echo "  git -C \"$repo_root\" remote get-url origin"
+  echo "  ssh -T git@$ssh_alias"
   echo
 }

--- a/lib/commands/apply.sh
+++ b/lib/commands/apply.sh
@@ -88,7 +88,7 @@ apply_to_current_repo() {
   local account
   account=$(get_account_by_id_or_alias "$key")
   if [[ -z "$account" ]]; then
-    die "No account matches '$key' (by id or ssh_alias). Run 'git-auto-switch list' to see available accounts."
+    die "Account '$key' not found (looked up by id and ssh_alias). Run 'git-auto-switch list' to see available accounts."
   fi
 
   if ! git rev-parse --git-dir >/dev/null 2>&1; then

--- a/lib/state/state.sh
+++ b/lib/state/state.sh
@@ -191,6 +191,13 @@ get_account() {
   echo "$STATE_JSON" | jq -r ".accounts[] | select(.id == \"$id\")"
 }
 
+# Get account by ID or SSH alias (matches whichever the user passed in)
+get_account_by_id_or_alias() {
+  local key="$1"
+  echo "$STATE_JSON" | jq --arg key "$key" \
+    '.accounts[] | select(.id == $key or .ssh_alias == $key)'
+}
+
 # Get account by index
 get_account_by_index() {
   local index="$1"

--- a/test/apply.bats
+++ b/test/apply.bats
@@ -1,0 +1,251 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# Source the apply command for cmd_apply / apply_to_current_repo
+setup_apply_command() {
+  source "$PROJECT_ROOT/lib/commands/apply.sh"
+}
+
+setup_test_repo() {
+  local repo_path="$1"
+  local remote_url="$2"
+
+  mkdir -p "$repo_path"
+  cd "$repo_path"
+  git init -q
+  git config user.name "Initial Name"
+  git config user.email "initial@example.com"
+  if [[ -n "$remote_url" ]]; then
+    git remote add origin "$remote_url"
+  fi
+}
+
+@test "apply <id> sets local git identity in current repository" {
+  create_test_state
+  save_state
+  setup_apply_command
+
+  setup_test_repo "$HOME/some/repo" "git@github.com:user/repo.git"
+  cd "$HOME/some/repo"
+
+  run apply_to_current_repo "personal"
+  [ "$status" -eq 0 ]
+
+  local local_name local_email
+  local_name=$(git -C "$HOME/some/repo" config --local --get user.name)
+  local_email=$(git -C "$HOME/some/repo" config --local --get user.email)
+  [ "$local_name" = "John Doe" ]
+  [ "$local_email" = "john@personal.com" ]
+}
+
+@test "apply <id> rewrites github.com origin to use SSH alias" {
+  create_test_state
+  save_state
+  setup_apply_command
+
+  setup_test_repo "$HOME/some/repo" "git@github.com:user/repo.git"
+  cd "$HOME/some/repo"
+
+  run apply_to_current_repo "personal"
+  [ "$status" -eq 0 ]
+
+  local new_url
+  new_url=$(git -C "$HOME/some/repo" remote get-url origin)
+  [ "$new_url" = "git@gh-personal:user/repo.git" ]
+}
+
+@test "apply <id> converts HTTPS origin to SSH with alias" {
+  create_test_state
+  save_state
+  setup_apply_command
+
+  setup_test_repo "$HOME/some/repo" "https://github.com/user/repo.git"
+  cd "$HOME/some/repo"
+
+  run apply_to_current_repo "personal"
+  [ "$status" -eq 0 ]
+
+  local new_url
+  new_url=$(git -C "$HOME/some/repo" remote get-url origin)
+  [ "$new_url" = "git@gh-personal:user/repo.git" ]
+}
+
+@test "apply <id> succeeds in repository without origin remote" {
+  create_test_state
+  save_state
+  setup_apply_command
+
+  setup_test_repo "$HOME/some/repo" ""
+  cd "$HOME/some/repo"
+
+  run apply_to_current_repo "personal"
+  [ "$status" -eq 0 ]
+
+  local local_email
+  local_email=$(git -C "$HOME/some/repo" config --local --get user.email)
+  [ "$local_email" = "john@personal.com" ]
+}
+
+@test "apply <id> works from a subdirectory of the repository" {
+  create_test_state
+  save_state
+  setup_apply_command
+
+  setup_test_repo "$HOME/some/repo" "git@github.com:user/repo.git"
+  mkdir -p "$HOME/some/repo/src/nested"
+  cd "$HOME/some/repo/src/nested"
+
+  run apply_to_current_repo "personal"
+  [ "$status" -eq 0 ]
+
+  local local_email new_url
+  local_email=$(git -C "$HOME/some/repo" config --local --get user.email)
+  new_url=$(git -C "$HOME/some/repo" remote get-url origin)
+  [ "$local_email" = "john@personal.com" ]
+  [ "$new_url" = "git@gh-personal:user/repo.git" ]
+}
+
+@test "apply <id> fails when account does not exist" {
+  create_test_state
+  save_state
+  setup_apply_command
+
+  setup_test_repo "$HOME/some/repo" "git@github.com:user/repo.git"
+  cd "$HOME/some/repo"
+
+  run apply_to_current_repo "nonexistent"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+
+  # Local config should not have been touched.
+  local local_email
+  local_email=$(git -C "$HOME/some/repo" config --local --get user.email)
+  [ "$local_email" = "initial@example.com" ]
+}
+
+@test "apply <id> fails when not in a git repository" {
+  create_test_state
+  save_state
+  setup_apply_command
+
+  mkdir -p "$HOME/not-a-repo"
+  cd "$HOME/not-a-repo"
+
+  run apply_to_current_repo "personal"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Not in a git repository"* ]]
+}
+
+@test "apply <id> leaves non-github remotes unchanged" {
+  create_test_state
+  save_state
+  setup_apply_command
+
+  setup_test_repo "$HOME/some/repo" "git@gitlab.com:user/repo.git"
+  cd "$HOME/some/repo"
+
+  run apply_to_current_repo "personal"
+  [ "$status" -eq 0 ]
+
+  local new_url
+  new_url=$(git -C "$HOME/some/repo" remote get-url origin)
+  [ "$new_url" = "git@gitlab.com:user/repo.git" ]
+}
+
+@test "apply accepts ssh_alias instead of account id" {
+  create_test_state
+  save_state
+  setup_apply_command
+
+  setup_test_repo "$HOME/some/repo" "git@github.com:user/repo.git"
+  cd "$HOME/some/repo"
+
+  # 'gh-personal' is the ssh_alias of the 'personal' account
+  run apply_to_current_repo "gh-personal"
+  [ "$status" -eq 0 ]
+
+  local new_url local_email
+  new_url=$(git -C "$HOME/some/repo" remote get-url origin)
+  local_email=$(git -C "$HOME/some/repo" config --local --get user.email)
+  [ "$new_url" = "git@gh-personal:user/repo.git" ]
+  [ "$local_email" = "john@personal.com" ]
+}
+
+@test "cmd_apply <id> dispatches to the per-repo branch" {
+  create_test_state
+  save_state
+  setup_apply_command
+
+  setup_test_repo "$HOME/some/repo" "git@github.com:user/repo.git"
+  cd "$HOME/some/repo"
+
+  run cmd_apply "personal"
+  [ "$status" -eq 0 ]
+
+  local new_url
+  new_url=$(git -C "$HOME/some/repo" remote get-url origin)
+  [ "$new_url" = "git@gh-personal:user/repo.git" ]
+}
+
+@test "cmd_apply <ssh_alias> dispatches and resolves the account" {
+  create_test_state
+  save_state
+  setup_apply_command
+
+  setup_test_repo "$HOME/some/repo" "git@github.com:user/repo.git"
+  cd "$HOME/some/repo"
+
+  # The documented invocation: pass the SSH alias instead of the id
+  run cmd_apply "gh-personal"
+  [ "$status" -eq 0 ]
+
+  local new_url local_email
+  new_url=$(git -C "$HOME/some/repo" remote get-url origin)
+  local_email=$(git -C "$HOME/some/repo" config --local --get user.email)
+  [ "$new_url" = "git@gh-personal:user/repo.git" ]
+  [ "$local_email" = "john@personal.com" ]
+}
+
+@test "apply <id> switches an already-aliased remote to a different alias" {
+  init_state
+  add_account "personal" "Personal" "gh-personal" "$HOME/.ssh/id_personal" \
+    '["'"$HOME"'/workspace/personal"]' "John Doe" "john@personal.com"
+  add_account "work" "Work" "gh-work" "$HOME/.ssh/id_work" \
+    '["'"$HOME"'/workspace/work"]' "John Work" "john@work.com"
+  save_state
+  setup_apply_command
+
+  setup_test_repo "$HOME/some/repo" "git@gh-personal:user/repo.git"
+  cd "$HOME/some/repo"
+
+  run apply_to_current_repo "work"
+  [ "$status" -eq 0 ]
+
+  local new_url local_email
+  new_url=$(git -C "$HOME/some/repo" remote get-url origin)
+  local_email=$(git -C "$HOME/some/repo" config --local --get user.email)
+  [ "$new_url" = "git@gh-work:user/repo.git" ]
+  [ "$local_email" = "john@work.com" ]
+}
+
+@test "apply <id> is idempotent when run twice" {
+  create_test_state
+  save_state
+  setup_apply_command
+
+  setup_test_repo "$HOME/some/repo" "git@github.com:user/repo.git"
+  cd "$HOME/some/repo"
+
+  run apply_to_current_repo "personal"
+  [ "$status" -eq 0 ]
+
+  run apply_to_current_repo "personal"
+  [ "$status" -eq 0 ]
+
+  local new_url local_email
+  new_url=$(git -C "$HOME/some/repo" remote get-url origin)
+  local_email=$(git -C "$HOME/some/repo" config --local --get user.email)
+  [ "$new_url" = "git@gh-personal:user/repo.git" ]
+  [ "$local_email" = "john@personal.com" ]
+}


### PR DESCRIPTION
## Summary

Adds support for `gas apply <id|ssh_alias>` to configure a single repository to use a specific account, without running a system-wide apply. Useful for one-off repos that sit outside any configured workspace, or when overriding the workspace default for a single project.

Closes #2.

## Approach

`cmd_apply` gets a one-line dispatch at the top: if a positional argument is given, route to a new `apply_to_current_repo()` helper; otherwise fall through to the existing system-wide path. The helper:

1. Looks up the account by id **or** ssh_alias (new `get_account_by_id_or_alias` helper). Either form works — `gas apply work` and `gas apply gh-work` resolve to the same account.
2. Refreshes `~/.ssh/config` only when the alias is missing (avoids backup churn on repeated invocations).
3. Sets local `user.name` / `user.email` via `git -C <repo_root> config ...` so the identity travels with the repo, even outside any workspace.
4. Rewrites the `origin` remote to use the SSH alias, normalizing first if the remote is already pointed at a *different* alias (so switching from `gh-personal` → `gh-work` actually changes the remote).

## Decision Record

- **Argument form** — accept both `id` and `ssh_alias`. AC #1 says "SSH config name" but the example (`gas apply gh-luongnv89`) is ambiguous; in this codebase the id and alias are commonly the same string. Accepting both eliminates the foot-gun.
- **Local `user.email` vs `--unset`** — set the local config explicitly. The audit `--fix` path *unsets* local email to defer to `includeIf`, but AC #4 (and the use case in the issue) expect this command to work for repos *outside* any configured workspace, where `includeIf` won't fire. Local config wins per-repo, so no global `includeIf` regressions.
- **SSH config refresh on first apply** — call `apply_ssh_config` if the alias isn't in `~/.ssh/config` yet. Prevents the rewritten remote (`git@gh-foo:...`) from being unresolvable.
- **No `ensure_ssh_key`** — that helper prompts interactively. Surface a warning instead and direct the user to system-wide `gas apply` for key generation.

## Changes

| File | Change |
|------|--------|
| `lib/commands/apply.sh` | Add `apply_to_current_repo`, dispatch from `cmd_apply` |
| `lib/state/state.sh` | Add `get_account_by_id_or_alias` |
| `lib/cli/help.sh` | Document `apply [id]` and add example |
| `README.md` | Add command-table row and "Applying an Account to the Current Repository" section |
| `CHANGELOG.md` | Unreleased entry |
| `test/apply.bats` | 13 new tests (NEW FILE) |

## Test Results

- `make lint` — passes (ShellCheck clean)
- `make test` — 72/72 pass (13 new in `test/apply.bats`, 59 existing untouched)
- End-to-end manual verification (alias form, id form, repeated apply, account switching) — all pass

## Acceptance Criteria Verification

| AC | Status | Evidence |
|----|--------|----------|
| 1. Command accepts an SSH config name | ✓ | `gas apply gh-luongnv89` works; alternate `gas apply <id>` also works (`get_account_by_id_or_alias`) |
| 2. Applies to current repo only | ✓ | Uses `git rev-parse --show-toplevel`; no global config writes |
| 3. Origin remote rewritten to use alias | ✓ | `git@github.com:` → `git@<alias>:`, including switch-from-other-alias case |
| 4. Local user.name / user.email configured | ✓ | `git -C "$repo_root" config user.{name,email}` (no `--global`) |
| 5. Documented in CLI help and README | ✓ | `lib/cli/help.sh`, `README.md` Applying section, table row |

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (72/72)
- [x] Manual smoke: `gas apply gh-<alias>` rewrites origin and sets local identity
- [x] Manual smoke: switching `gas apply work` after `gas apply personal` correctly re-rewrites the alias
- [x] Manual smoke: error paths (`gas apply nonexistent`, `gas apply <id>` outside a repo)
- [ ] Reviewer sanity-check on a real account configuration